### PR TITLE
[K5P-49] [feat] 청구생성배치

### DIFF
--- a/src/main/java/site/billingwise/batch/server_batch/batch/generateinvoice/jdbc/JdbcGenerateInvoiceJobConfig.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/generateinvoice/jdbc/JdbcGenerateInvoiceJobConfig.java
@@ -52,7 +52,7 @@ public class JdbcGenerateInvoiceJobConfig {
         return new JdbcCursorItemReaderBuilder<Contract>()
                 .name("jdbcContractItemReader")
                 .fetchSize(CHUNK_SIZE)
-                .sql("select c.*, pt.payment_type_id, pt.name as payment_type_name, it.invoice_type_id, it.name as invoice_type_name " +
+                .sql("select c.*, pt.payment_type_id, pt.name as payment_type_name, it.invoice_type_id, it.name as invoice_type_name, c.is_deleted " +
                         "from contract c " +
                         "join contract_status cs ON c.contract_status_id = cs.contract_status_id " +
                         "join payment_type pt ON c.payment_type_id = pt.payment_type_id " +

--- a/src/main/java/site/billingwise/batch/server_batch/batch/generateinvoice/jdbc/JdbcGenerateInvoiceWriter.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/generateinvoice/jdbc/JdbcGenerateInvoiceWriter.java
@@ -38,6 +38,11 @@ public class JdbcGenerateInvoiceWriter implements ItemWriter<Contract> {
         List<Invoice> invoices = new ArrayList<>();
 
         for(Contract contract : chunk) {
+
+            if(contract.getIsDeleted()){
+                continue;
+            }
+
             // 수동 청구가 이미 만들어지면, 청구 생성 X
             if(!invoiceExists(contract, nextMonthValue, yearValue)){
                 // 약정일
@@ -53,6 +58,9 @@ public class JdbcGenerateInvoiceWriter implements ItemWriter<Contract> {
                         .chargeAmount(contract.getItemPrice() * contract.getItemAmount())
                         .contractDate(setInvoiceDate)
                         .dueDate(payDueDate)
+                        .isDeleted(false)  // isDeleted 필드 값을 설정
+                        .createdAt(now)  // createdAt 필드 값을 설정
+                        .updatedAt(now)  // updatedAt 필드 값을 설정
                         .build();
 
                 invoices.add(invoice);

--- a/src/main/java/site/billingwise/batch/server_batch/batch/generateinvoice/rowmapper/JdbcContractRowMapper.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/generateinvoice/rowmapper/JdbcContractRowMapper.java
@@ -17,6 +17,7 @@ public class JdbcContractRowMapper implements RowMapper<Contract> {
                 .itemAmount(rs.getInt("item_amount"))
                 .contractCycle(rs.getInt("contract_cycle"))
                 .paymentDueCycle(rs.getInt("payment_due_cycle"))
+                .isDeleted(rs.getBoolean("is_deleted"))
                 .paymentType(
                         PaymentType.builder()
                                 .id(rs.getLong("payment_type_id"))
@@ -29,7 +30,9 @@ public class JdbcContractRowMapper implements RowMapper<Contract> {
                                 .name(rs.getString("invoice_type_name"))
                                 .build()
                 )
-
+                .createdAt(rs.getTimestamp("created_at").toLocalDateTime())
+                .updatedAt(rs.getTimestamp("updated_at").toLocalDateTime())
+                .isDeleted(rs.getBoolean("is_deleted"))
                 .build();
     }
 }

--- a/src/main/java/site/billingwise/batch/server_batch/domain/common/BaseEntity.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/common/BaseEntity.java
@@ -5,6 +5,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -14,6 +16,8 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@SuperBuilder
+@NoArgsConstructor
 public abstract class BaseEntity {
 
     @CreatedDate

--- a/src/main/java/site/billingwise/batch/server_batch/domain/contract/Contract.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/contract/Contract.java
@@ -2,6 +2,7 @@ package site.billingwise.batch.server_batch.domain.contract;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 import site.billingwise.batch.server_batch.domain.invoice.Invoice;
 import site.billingwise.batch.server_batch.domain.invoice.InvoiceType;
@@ -13,7 +14,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Contract extends BaseEntity {

--- a/src/main/java/site/billingwise/batch/server_batch/domain/contract/ContractStatus.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/contract/ContractStatus.java
@@ -3,6 +3,7 @@ package site.billingwise.batch.server_batch.domain.contract;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 
 import java.util.ArrayList;
@@ -10,7 +11,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ContractStatus extends BaseEntity {

--- a/src/main/java/site/billingwise/batch/server_batch/domain/contract/PaymentType.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/contract/PaymentType.java
@@ -23,7 +23,7 @@ public class PaymentType extends BaseEntity {
     @Column(length = 50, nullable = false)
     private String name;
 
-    @Column(name = "basic_payment_type",nullable = false)
+    @Column(name = "is_basic",nullable = false)
     private Boolean isBasic;
 
     @OneToMany(mappedBy = "paymentType")

--- a/src/main/java/site/billingwise/batch/server_batch/domain/contract/PaymentType.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/contract/PaymentType.java
@@ -2,6 +2,7 @@ package site.billingwise.batch.server_batch.domain.contract;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 import site.billingwise.batch.server_batch.domain.invoice.Invoice;
 
@@ -10,7 +11,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentType extends BaseEntity {

--- a/src/main/java/site/billingwise/batch/server_batch/domain/invoice/Invoice.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/invoice/Invoice.java
@@ -2,6 +2,7 @@ package site.billingwise.batch.server_batch.domain.invoice;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 import site.billingwise.batch.server_batch.domain.contract.Contract;
 import site.billingwise.batch.server_batch.domain.contract.PaymentType;
@@ -11,7 +12,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Invoice extends BaseEntity {

--- a/src/main/java/site/billingwise/batch/server_batch/domain/invoice/InvoiceType.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/invoice/InvoiceType.java
@@ -2,6 +2,7 @@ package site.billingwise.batch.server_batch.domain.invoice;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 import site.billingwise.batch.server_batch.domain.contract.Contract;
 
@@ -10,7 +11,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class InvoiceType extends BaseEntity {

--- a/src/main/java/site/billingwise/batch/server_batch/domain/invoice/PaymentStatus.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/invoice/PaymentStatus.java
@@ -2,6 +2,7 @@ package site.billingwise.batch.server_batch.domain.invoice;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 
 import java.util.ArrayList;
@@ -9,7 +10,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentStatus extends BaseEntity {

--- a/src/main/java/site/billingwise/batch/server_batch/domain/item/Item.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/item/Item.java
@@ -2,6 +2,7 @@ package site.billingwise.batch.server_batch.domain.item;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 import site.billingwise.batch.server_batch.domain.contract.Contract;
 import site.billingwise.batch.server_batch.domain.user.Client;
@@ -11,7 +12,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Item extends BaseEntity {

--- a/src/main/java/site/billingwise/batch/server_batch/domain/member/ConsentAccount.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/member/ConsentAccount.java
@@ -2,11 +2,12 @@ package site.billingwise.batch.server_batch.domain.member;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ConsentAccount extends BaseEntity {

--- a/src/main/java/site/billingwise/batch/server_batch/domain/member/Member.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/member/Member.java
@@ -2,6 +2,7 @@ package site.billingwise.batch.server_batch.domain.member;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 import site.billingwise.batch.server_batch.domain.contract.Contract;
 import site.billingwise.batch.server_batch.domain.user.Client;
@@ -11,7 +12,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(uniqueConstraints = {

--- a/src/main/java/site/billingwise/batch/server_batch/domain/payment/Payment.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/payment/Payment.java
@@ -2,12 +2,13 @@ package site.billingwise.batch.server_batch.domain.payment;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 import site.billingwise.batch.server_batch.domain.invoice.Invoice;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Payment extends BaseEntity {

--- a/src/main/java/site/billingwise/batch/server_batch/domain/payment/PaymentAccount.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/payment/PaymentAccount.java
@@ -2,11 +2,12 @@ package site.billingwise.batch.server_batch.domain.payment;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentAccount extends BaseEntity {

--- a/src/main/java/site/billingwise/batch/server_batch/domain/payment/PaymentCard.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/payment/PaymentCard.java
@@ -2,11 +2,12 @@ package site.billingwise.batch.server_batch.domain.payment;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PaymentCard extends BaseEntity {

--- a/src/main/java/site/billingwise/batch/server_batch/domain/user/Client.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/user/Client.java
@@ -2,6 +2,7 @@ package site.billingwise.batch.server_batch.domain.user;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 import site.billingwise.batch.server_batch.domain.item.Item;
 import site.billingwise.batch.server_batch.domain.member.Member;
@@ -11,7 +12,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Client extends BaseEntity {

--- a/src/main/java/site/billingwise/batch/server_batch/domain/user/User.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/user/User.java
@@ -2,11 +2,12 @@ package site.billingwise.batch.server_batch.domain.user;
 
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 import site.billingwise.batch.server_batch.domain.common.BaseEntity;
 
 @Entity
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class User extends BaseEntity {

--- a/src/main/resources/status.sql
+++ b/src/main/resources/status.sql
@@ -8,7 +8,7 @@ VALUES
 
 
 -- 결제 수단
-INSERT INTO payment_type (payment_type_id, name, basic_payment_type, is_deleted, created_at, updated_at)
+INSERT INTO payment_type (payment_type_id, name, is_basic, is_deleted, created_at, updated_at)
 VALUES
     (1, '납부자 결제', false, false, NOW(), NOW()),
     (2, '자동 이체', true, false, NOW(), NOW());

--- a/src/test/java/site/billingwise/batch/server_batch/batch/generateinvoice/jdbc/JdbcGenerateInvoiceWriterTest.java
+++ b/src/test/java/site/billingwise/batch/server_batch/batch/generateinvoice/jdbc/JdbcGenerateInvoiceWriterTest.java
@@ -16,6 +16,7 @@ import site.billingwise.batch.server_batch.domain.contract.PaymentType;
 import site.billingwise.batch.server_batch.domain.invoice.InvoiceType;
 import site.billingwise.batch.server_batch.domain.invoice.PaymentStatus;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -64,6 +65,9 @@ class JdbcGenerateInvoiceWriterTest {
                 .itemAmount(2)
                 .paymentType(paymentType)
                 .invoiceType(autoInvoiceType)
+                .isDeleted(false)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
                 .build();
 
         List<Contract> contracts = Arrays.asList(contract);


### PR DESCRIPTION
## 관련 이슈

- [K5P-49]

## 구현 기능

- 데이터 타입 (간편동의 칼럼명 변경 ( is_basic으로 ))
- 청구 데이터 생성에 해지 된( 소프트 딜리트 ) 계약 정보 처리 로직 구현
- 엔티티 수정(BaseEntity에 @SuperBuilder 사용)
- 테스트 코드 수정

## 참고 사항

[K5P-49]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
