### PR TITLE
[K5P-53] [feat] 결제 및 청구서 납부서 생성(발송) 배치 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+	testImplementation 'org.mockito:mockito-junit-jupiter'
 	testImplementation 'org.springframework.batch:spring-batch-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/site/billingwise/batch/server_batch/batch/common/GenerateInvoiceScheduler.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/common/GenerateInvoiceScheduler.java
@@ -1,8 +1,7 @@
 package site.billingwise.batch.server_batch.batch.common;
 
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
@@ -15,61 +14,83 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
-
 @Configuration
 @EnableScheduling
 @RequiredArgsConstructor
+@Slf4j
 public class GenerateInvoiceScheduler {
 
-    private static final Logger logger = LoggerFactory.getLogger(GenerateInvoiceScheduler.class);
     private final JobLauncher jobLauncher;
     private final Job generateInvoiceJob;
     private final Job jdbcGenerateInvoiceJob;
+    private final Job invoiceProcessingJob;
 
-    //    일단 0,30초마다 실행하도록 실행
-    @Scheduled(cron = "0,30 * * * * ?")
-    public void generateInvoice() {
-        JobParameters jobParameters = new JobParametersBuilder()
-                .addLong("invoice", System.currentTimeMillis())
-                .toJobParameters();
-        try {
-            logger.info("JPA 배치 프로그램 실행 시작");
-            jobLauncher.run(generateInvoiceJob, jobParameters);
-            logger.info("JPA 배치 프로그램 실행 완료");
-        } catch (JobExecutionAlreadyRunningException e) {
-            logger.error("JobExecutionAlreadyRunningException 발생: ", e);
-        } catch (JobRestartException e) {
-            logger.error("JobRestartException 발생: ", e);
-        } catch (JobInstanceAlreadyCompleteException e) {
-            logger.error("JobInstanceAlreadyCompleteException 발생: ", e);
-        } catch (JobParametersInvalidException e) {
-            logger.error("JobParametersInvalidException 발생: ", e);
-        } catch (Exception e) {
-            logger.error("예기치 않은 오류 발생: ", e);
-        }
-    }
+//    // 0, 30초마다 실행
+//    @Scheduled(cron = "0,30 * * * * ?")
+//    public void generateInvoice() {
+//        JobParameters jobParameters = new JobParametersBuilder()
+//                .addLong("invoice", System.currentTimeMillis())
+//                .toJobParameters();
+//        try {
+//            log.info("JPA 배치 프로그램 실행 시작");
+//            jobLauncher.run(generateInvoiceJob, jobParameters);
+//            log.info("JPA 배치 프로그램 실행 완료");
+//        } catch (JobExecutionAlreadyRunningException e) {
+//            log.error("JobExecutionAlreadyRunningException 발생: ", e);
+//        } catch (JobRestartException e) {
+//            log.error("JobRestartException 발생: ", e);
+//        } catch (JobInstanceAlreadyCompleteException e) {
+//            log.error("JobInstanceAlreadyCompleteException 발생: ", e);
+//        } catch (JobParametersInvalidException e) {
+//            log.error("JobParametersInvalidException 발생: ", e);
+//        } catch (Exception e) {
+//            log.error("예기치 않은 오류 발생: ", e);
+//        }
+//    }
+//
+//    // 15, 45초마다 실행
+//    @Scheduled(cron = "15,45 * * * * ?")
+//    public void jdbcGenerateInvoice() {
+//        JobParameters jobParameters = new JobParametersBuilder()
+//                .addLong("jdbcInvoice", System.currentTimeMillis())
+//                .toJobParameters();
+//        try {
+//            log.info("JDBC 배치 프로그램 실행 시작");
+//            jobLauncher.run(jdbcGenerateInvoiceJob, jobParameters);
+//            log.info("JDBC 배치 프로그램 실행 완료");
+//        } catch (JobExecutionAlreadyRunningException e) {
+//            log.error("JobExecutionAlreadyRunningException 발생: ", e);
+//        } catch (JobRestartException e) {
+//            log.error("JobRestartException 발생: ", e);
+//        } catch (JobInstanceAlreadyCompleteException e) {
+//            log.error("JobInstanceAlreadyCompleteException 발생: ", e);
+//        } catch (JobParametersInvalidException e) {
+//            log.error("JobParametersInvalidException 발생: ", e);
+//        } catch (Exception e) {
+//            log.error("예기치 않은 오류 발생: ", e);
+//        }
+//    }
 
-
-    //    일단 15,45초마다 실행하도록 실행
+    // 15, 45초마다 실행
     @Scheduled(cron = "15,45 * * * * ?")
-    public void jdbcgenerateInvoice() {
+    public void runInvoiceProcessingJob() {
         JobParameters jobParameters = new JobParametersBuilder()
-                .addLong("jdbcInvoice", System.currentTimeMillis())
+                .addLong("InvoiceProcessingJob", System.currentTimeMillis())
                 .toJobParameters();
         try {
-            logger.info("JDBC 배치 프로그램 실행 시작");
-            jobLauncher.run(jdbcGenerateInvoiceJob, jobParameters);
-            logger.info("JDBC 배치 프로그램 실행 완료");
+            log.info("Invoice Processing Job 실행 시작");
+            jobLauncher.run(invoiceProcessingJob, jobParameters);
+            log.info("Invoice Processing Job 실행 완료");
         } catch (JobExecutionAlreadyRunningException e) {
-            logger.error("JobExecutionAlreadyRunningException 발생: ", e);
+            log.error("JobExecutionAlreadyRunningException 발생: ", e);
         } catch (JobRestartException e) {
-            logger.error("JobRestartException 발생: ", e);
+            log.error("JobRestartException 발생: ", e);
         } catch (JobInstanceAlreadyCompleteException e) {
-            logger.error("JobInstanceAlreadyCompleteException 발생: ", e);
+            log.error("JobInstanceAlreadyCompleteException 발생: ", e);
         } catch (JobParametersInvalidException e) {
-            logger.error("JobParametersInvalidException 발생: ", e);
+            log.error("JobParametersInvalidException 발생: ", e);
         } catch (Exception e) {
-            logger.error("예기치 않은 오류 발생: ", e);
+            log.error("예기치 않은 오류 발생: ", e);
         }
     }
 }

--- a/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/config/InvoiceProcessingJobConfig.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/config/InvoiceProcessingJobConfig.java
@@ -1,0 +1,74 @@
+package site.billingwise.batch.server_batch.batch.invoiceprocessing.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.builder.JdbcCursorItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import site.billingwise.batch.server_batch.batch.invoiceprocessing.rowmapper.InvoiceRowMapper;
+import site.billingwise.batch.server_batch.batch.invoiceprocessing.writer.InvoiceSendingAndPaymentManageWriter;
+import site.billingwise.batch.server_batch.batch.listner.JobCompletionCheckListener;
+import site.billingwise.batch.server_batch.batch.service.EmailService;
+import site.billingwise.batch.server_batch.domain.invoice.Invoice;
+
+import javax.sql.DataSource;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class InvoiceProcessingJobConfig {
+
+    private final int CHUNK_SIZE = 100;
+    private final DataSource dataSource;
+    private final JdbcTemplate jdbcTemplate;
+    private final JobCompletionCheckListener jobCompletionCheckListener;
+    private final EmailService emailService;
+
+    // 결제 기한 체크 로직 step 아직 개발 x
+    @Bean
+    public Job invoiceProcessingJob(JobRepository jobRepository, Step invoiceSendingAndPaymentManageStep) {
+        return new JobBuilder("InvoiceProcessingJob", jobRepository)
+                .listener(jobCompletionCheckListener)
+                .start(invoiceSendingAndPaymentManageStep)
+//                .next(invoiceDueDateUpdateStep)
+                .build();
+    }
+
+    @Bean
+    public Step invoiceSendingAndPaymentManageStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("InvoiceSendingAndPaymentManageStep", jobRepository)
+                .<Invoice, Invoice>chunk(CHUNK_SIZE, transactionManager)
+                .reader(invoiceSendingAndPaymentManageReader())
+                .writer(invoiceSendingAndPaymentManageWriter())
+                .build();
+    }
+
+    private ItemReader<? extends Invoice> invoiceSendingAndPaymentManageReader() {
+
+        return new JdbcCursorItemReaderBuilder<Invoice>()
+                .name("invoiceSendingAndPaymentManageReader")
+                .fetchSize(CHUNK_SIZE)
+                .sql("select i.*, c.member_id, m.email, m.name, ca.number, ca.bank, ca.owner, i.is_deleted " +
+                        "from invoice i " +
+                        "join contract c ON i.contract_id = c.contract_id " +
+                        "join member m ON c.member_id = m.member_id " +
+                        "left join consent_account ca ON m.member_id = ca.member_id " +
+                        "where i.contract_date >= curdate() AND i.contract_date < curdate() + interval 1 day")
+                .rowMapper(new InvoiceRowMapper())
+                .dataSource(dataSource)
+                .build();
+    }
+
+    private ItemWriter<? super Invoice> invoiceSendingAndPaymentManageWriter() {
+        return new InvoiceSendingAndPaymentManageWriter(jdbcTemplate, emailService);
+    }
+}

--- a/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/rowmapper/InvoiceRowMapper.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/rowmapper/InvoiceRowMapper.java
@@ -1,0 +1,53 @@
+package site.billingwise.batch.server_batch.batch.invoiceprocessing.rowmapper;
+
+import org.springframework.jdbc.core.RowMapper;
+import site.billingwise.batch.server_batch.domain.contract.Contract;
+import site.billingwise.batch.server_batch.domain.contract.PaymentType;
+import site.billingwise.batch.server_batch.domain.invoice.Invoice;
+import site.billingwise.batch.server_batch.domain.member.ConsentAccount;
+import site.billingwise.batch.server_batch.domain.member.Member;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class InvoiceRowMapper implements RowMapper<Invoice> {
+
+    @Override
+    public Invoice mapRow(ResultSet rs, int rowNum) throws SQLException {
+
+
+        ConsentAccount consentAccount = ConsentAccount.builder()
+                .number(rs.getString("number"))
+                .bank(rs.getString("bank"))
+                .owner(rs.getString("owner"))
+                .build();
+
+
+        Member member = Member.builder()
+                .id(rs.getLong("member_id"))
+                .email(rs.getString("email"))
+                .name(rs.getString("name"))
+                .consentAccount(consentAccount)
+                .build();
+
+
+        Contract contract = Contract.builder()
+                .member(member)
+                .build();
+
+        PaymentType paymentType = PaymentType.builder()
+                .id(rs.getLong("payment_type_id"))
+                .build();
+
+
+        return Invoice.builder()
+                .id(rs.getLong("invoice_id"))
+                .contract(contract)
+                .chargeAmount(rs.getLong("charge_amount"))
+                .contractDate(rs.getTimestamp("contract_date").toLocalDateTime())
+                .dueDate(rs.getTimestamp("due_date").toLocalDateTime())
+                .paymentType(paymentType)
+                .isDeleted(rs.getBoolean("is_deleted"))
+                .build();
+    }
+}

--- a/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/writer/InvoiceSendingAndPaymentManageWriter.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/writer/InvoiceSendingAndPaymentManageWriter.java
@@ -1,0 +1,98 @@
+package site.billingwise.batch.server_batch.batch.invoiceprocessing.writer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import site.billingwise.batch.server_batch.batch.service.EmailService;
+import site.billingwise.batch.server_batch.domain.invoice.Invoice;
+import site.billingwise.batch.server_batch.domain.member.ConsentAccount;
+
+import static site.billingwise.batch.server_batch.batch.util.StatusConstants.*;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class InvoiceSendingAndPaymentManageWriter implements ItemWriter<Invoice> {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final EmailService emailService;
+
+    @Override
+    public void write(Chunk<? extends Invoice> chunk) {
+
+        for(Invoice invoice : chunk) {
+
+            if(invoice.getIsDeleted()) {
+                continue;
+            }
+            // 자동 이체
+            if(invoice.getPaymentType().getId() == INVOICE_TYPE_AUTOMATIC_BILLING) {
+
+                ConsentAccount consentAccount = invoice.getContract().getMember().getConsentAccount();
+                boolean paymentAttempt = false;
+
+                if (consentAccount != null) {
+                    // 결제 시도( 아직 개발되지 않았음 )
+                    paymentAttempt = processAutoPayment(invoice);
+                }
+
+                // 결제 성공 시
+                if (paymentAttempt) {
+
+                    updatePaymentStatus(invoice.getId(), PAYMENT_STATUS_COMPLETED);
+                    insertPaymentRecord(invoice, consentAccount);
+                    emailService.sendPaymentSuccessMailCode(invoice.getContract().getMember().getEmail(), invoice, consentAccount);
+
+                // 결제 실패 시
+                } else {
+
+                    emailService.sendPaymentFailMailCode(invoice.getContract().getMember().getEmail(), invoice, consentAccount);
+                    updateFailPaymentStatus(invoice.getId());
+                }
+
+            // 납부자 결제
+            } else if(invoice.getPaymentType().getId() == INVOICE_TYPE_MANUAL_BILLING){
+
+                emailService.sendInvoiceMail(invoice.getContract().getMember().getEmail(), invoice);
+                updatePaymentStatus(invoice.getId(), PAYMENT_STATUS_PENDING);
+            }
+        }
+    }
+
+
+
+    private void updateFailPaymentStatus(Long invoiceId) {
+        String sql = "update invoice set updated_at = now() where invoice_id = ?";
+        jdbcTemplate.update(sql,  invoiceId);
+    }
+
+
+    private void insertPaymentRecord(Invoice invoice, ConsentAccount consentAccount) {
+        String sql = "insert into payment (invoice_id, payment_method, pay_amount, created_at, updated_at, is_deleted) values (?, ?, ?, NOW(), NOW(), false)";
+        jdbcTemplate.update(sql, invoice.getId(), "계좌이체", invoice.getChargeAmount());
+        // 납부 계좌 테이블에 데이터 넣기 ( 결재 성공의 경우 )
+        insertPaymentAccount(invoice.getId(), consentAccount);
+    }
+
+
+    private void insertPaymentAccount(Long invoiceId, ConsentAccount consentAccount) {
+        String sql = "insert into payment_account (invoice_id, number, bank, owner, created_at, updated_at, is_deleted) values (?, ?, ?, ?, now(), now(), false)";
+        jdbcTemplate.update(sql, invoiceId, consentAccount.getNumber(), consentAccount.getBank(), consentAccount.getOwner());
+    }
+
+
+    private void updatePaymentStatus(Long invoiceId, long statusId) {
+        String sql = "update invoice set payment_status_id = ?, updated_at = now() where invoice_id = ?";
+        jdbcTemplate.update(sql, statusId, invoiceId);
+    }
+
+    //결제 시도
+    private boolean processAutoPayment(Invoice invoice) {
+        // 결제 시도 로직을 들어갈 곳
+
+        return true;
+    }
+}

--- a/src/main/java/site/billingwise/batch/server_batch/batch/listner/JobCompletionCheckListener.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/listner/JobCompletionCheckListener.java
@@ -1,38 +1,38 @@
 package site.billingwise.batch.server_batch.batch.listner;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.listener.JobExecutionListenerSupport;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.logging.Logger;
 
 
 @Component
+@Slf4j
 public class JobCompletionCheckListener extends JobExecutionListenerSupport {
 
-    private static final Logger log = Logger.getLogger(JobCompletionCheckListener.class.getName());
     private LocalDateTime startTime;
     private LocalDateTime endTime;
 
     @Override
     public void beforeJob(JobExecution jobExecution) {
         startTime = LocalDateTime.now();
-        log.info("Job started at: " + startTime);
+        log.info("Job started at: {}", startTime);
     }
 
     @Override
     public void afterJob(JobExecution jobExecution) {
         endTime = LocalDateTime.now();
-        log.info("Job ended at: " + endTime);
+        log.info("Job ended at: {}",  endTime);
 
         Duration duration = Duration.between(startTime, endTime);
         long seconds = duration.getSeconds();
         long minutes = seconds / 60;
         seconds = seconds % 60;
 
-        log.info("Job duration: " + minutes + " minutes and " + seconds + " seconds");
+        log.info("Job duration: {} minutes and {} seconds", minutes, seconds);
         super.afterJob(jobExecution);
     }
 }

--- a/src/main/java/site/billingwise/batch/server_batch/batch/service/EmailService.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/service/EmailService.java
@@ -1,0 +1,112 @@
+package site.billingwise.batch.server_batch.batch.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import site.billingwise.batch.server_batch.domain.invoice.Invoice;
+import site.billingwise.batch.server_batch.domain.member.ConsentAccount;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String fromMail;
+
+
+    // 결제 실패
+    public void sendPaymentFailMailCode(String email, Invoice invoice, ConsentAccount consentAccount) {
+        try {
+            MimeMessage message = createFailMail(email, invoice, consentAccount);
+            mailSender.send(message);
+            log.info("결제 실패 이메일이 성공적으로 전송되었습니다. 수신자: {}", email);
+        } catch (MessagingException e) {
+            log.error("결제 실패 이메일 전송 중 오류가 발생했습니다. 수신자: {}", email, e);
+        }
+    }
+
+    // 결제 성공
+    public void sendPaymentSuccessMailCode(String email, Invoice invoice, ConsentAccount consentAccount) {
+        try {
+            MimeMessage message = createSuccessMail(email, invoice, consentAccount);
+            mailSender.send(message);
+            log.info("결제 성공 이메일이 성공적으로 전송되었습니다. 수신자: {}", email);
+        } catch (MessagingException e) {
+            log.error("결제 성공 이메일 전송 중 오류가 발생했습니다. 수신자: {}", email, e);
+        }
+    }
+
+    // 청구서 발송
+    public void sendInvoiceMail(String email, Invoice invoice) {
+        try {
+            MimeMessage message = createInvoiceMail(email, invoice);
+            mailSender.send(message);
+            log.info("청구서 이메일이 성공적으로 전송되었습니다. 수신자: {}", email);
+        } catch (MessagingException e) {
+            log.error("청구서 이메일 전송 중 오류가 발생했습니다. 수신자: {}", email, e);
+        }
+    }
+
+    private MimeMessage createSuccessMail(String email, Invoice invoice, ConsentAccount consentAccount) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        helper.setFrom(fromMail);
+        helper.setTo(email);
+        helper.setSubject("[빌링와이즈] 결제 성공");
+        String body = "<h1>안녕하세요, 빌링와이즈 입니다.</h1>"
+                + "<p>결제가 성공적으로 처리되었습니다.</p>"
+                + "<p>청구 금액: " + invoice.getChargeAmount() + "</p>"
+                + "<p>은행: " + consentAccount.getBank() + "</p>"
+                + "<p>예금주: " + consentAccount.getOwner() + "</p>"
+                + "<p>계좌번호: " + consentAccount.getNumber() + "</p>"
+                + "<p>고객 문의 번호: " + "010-xxxx-xxxx " + "</p>";
+        helper.setText(body, true);
+
+        return message;
+    }
+
+    private MimeMessage createFailMail(String email, Invoice invoice, ConsentAccount consentAccount) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        helper.setFrom(fromMail);
+        helper.setTo(email);
+        helper.setSubject("[빌링와이즈] 결제 실패");
+        String body = "<h1>안녕하세요, 빌링와이즈 입니다.</h1>"
+                + "<p>결제가 실패하였습니다.</p>"
+                + "<p>청구 금액: " + invoice.getChargeAmount() + "</p>"
+                + "<p>은행: " + consentAccount.getBank() + "</p>"
+                + "<p>예금주: " + consentAccount.getOwner() + "</p>"
+                + "<p>계좌번호: " + consentAccount.getNumber() + "</p>"
+                + "<p>고객 문의 번호: " + "010-xxxx-xxxx " + "</p>";
+        helper.setText(body, true);
+
+        return message;
+    }
+
+    private MimeMessage createInvoiceMail(String email, Invoice invoice ) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        helper.setFrom(fromMail);
+        helper.setTo(email);
+        helper.setSubject("[빌링와이즈] 청구서 발송");
+        String body = "<h1>안녕하세요, 빌링와이즈 입니다.</h1>"
+                + "<p>청구서가 발송되었습니다.</p>"
+                + "<p>청구 금액: " + invoice.getChargeAmount() + "</p>"
+                + "<p>고객 문의 번호: " + "010-xxxx-xxxx " + "</p>";
+        // url 만들 예정
+        helper.setText(body, true);
+
+        return message;
+    }
+}

--- a/src/main/java/site/billingwise/batch/server_batch/batch/util/StatusConstants.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/util/StatusConstants.java
@@ -1,0 +1,23 @@
+package site.billingwise.batch.server_batch.batch.util;
+
+public class StatusConstants {
+
+    // 계약 상태
+    public static final long CONTRACT_STATUS_PENDING = 1L; // 대기
+    public static final long CONTRACT_STATUS_IN_PROGRESS = 2L; // 진행
+    public static final long CONTRACT_STATUS_TERMINATED = 3L; // 종료
+
+    // 납부 상태
+    public static final long PAYMENT_STATUS_UNPAID = 1L;   // 미납
+    public static final long PAYMENT_STATUS_COMPLETED = 2L;   // 완납
+    public static final long PAYMENT_STATUS_PENDING = 3L;   // 대기
+
+    // 청구 타입
+    public static final long INVOICE_TYPE_AUTOMATIC_BILLING = 1L;   // 자동청구
+    public static final long INVOICE_TYPE_MANUAL_BILLING = 2L;   // 수동청구
+
+    // 결제 수단
+    public static final long PAYMENT_TYPE_PAYER_PAYMENT = 1L;   // 납부자 결제
+    public static final long PAYMENT_TYPE_AUTOMATIC_TRANSFER = 2L;   // 자동 이체
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,9 +31,10 @@ spring:
     properties:
       mail:
         smtp:
+          auth: true
           starttls:
             enable: true
-          auth: true
+
 ---
 spring:
   batch:

--- a/src/test/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/writer/InvoiceSendingAndPaymentManageWriterTest.java
+++ b/src/test/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/writer/InvoiceSendingAndPaymentManageWriterTest.java
@@ -1,0 +1,106 @@
+package site.billingwise.batch.server_batch.batch.invoiceprocessing.writer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import site.billingwise.batch.server_batch.batch.service.EmailService;
+import site.billingwise.batch.server_batch.domain.contract.Contract;
+import site.billingwise.batch.server_batch.domain.contract.PaymentType;
+import site.billingwise.batch.server_batch.domain.invoice.Invoice;
+import site.billingwise.batch.server_batch.domain.member.ConsentAccount;
+import site.billingwise.batch.server_batch.domain.member.Member;
+
+import java.lang.reflect.Method;
+
+import static org.mockito.Mockito.verify;
+import static site.billingwise.batch.server_batch.batch.util.StatusConstants.INVOICE_TYPE_AUTOMATIC_BILLING;
+import static site.billingwise.batch.server_batch.batch.util.StatusConstants.PAYMENT_STATUS_COMPLETED;
+
+@ExtendWith(MockitoExtension.class)
+public class InvoiceSendingAndPaymentManageWriterTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private EmailService emailService;
+
+    @InjectMocks
+    private InvoiceSendingAndPaymentManageWriter writer;
+
+    private Invoice invoice;
+
+    @BeforeEach
+    public void setUp() {
+        Member member = Member.builder()
+                .email("test@naver.com")
+                .build();
+
+        Contract contract = Contract.builder()
+                .member(member)
+                .build();
+
+        PaymentType paymentType = PaymentType.builder()
+                .id(INVOICE_TYPE_AUTOMATIC_BILLING)
+                .build();
+
+        invoice = Invoice.builder()
+                .isDeleted(false)
+                .contract(contract)
+                .paymentType(paymentType)
+                .build();
+    }
+
+    @Test
+    @DisplayName("결제 실패 시 수정 시각 업데이트")
+    public void testUpdateFailPaymentStatus() throws Exception {
+        Method method = InvoiceSendingAndPaymentManageWriter.class.getDeclaredMethod("updateFailPaymentStatus", Long.class);
+        method.setAccessible(true);
+        method.invoke(writer, 1L);
+        verify(jdbcTemplate).update("update invoice set updated_at = now() where invoice_id = ?", 1L);
+    }
+
+    @Test
+    @DisplayName("결제 성공 시 납부 테이블 데이터 입력")
+    public void testInsertPaymentRecord() throws Exception {
+        ConsentAccount consentAccount = ConsentAccount.builder()
+                .number("12345")
+                .bank("bank")
+                .owner("변현진")
+                .build();
+
+        Method method = InvoiceSendingAndPaymentManageWriter.class.getDeclaredMethod("insertPaymentRecord", Invoice.class, ConsentAccount.class);
+        method.setAccessible(true);
+        method.invoke(writer, invoice, consentAccount);
+        verify(jdbcTemplate).update("insert into payment (invoice_id, payment_method, pay_amount, created_at, updated_at, is_deleted) values (?, ?, ?, NOW(), NOW(), false)", invoice.getId(), "계좌이체", invoice.getChargeAmount());
+    }
+
+    @Test
+    @DisplayName("결제 성공 납부 계좌 테이블 데이터 입력")
+    public void testInsertPaymentAccount() throws Exception {
+        ConsentAccount consentAccount = ConsentAccount.builder()
+                .number("12345")
+                .bank("bank")
+                .owner("변현진")
+                .build();
+
+        Method method = InvoiceSendingAndPaymentManageWriter.class.getDeclaredMethod("insertPaymentAccount", Long.class, ConsentAccount.class);
+        method.setAccessible(true);
+        method.invoke(writer, 1L, consentAccount);
+        verify(jdbcTemplate).update("insert into payment_account (invoice_id, number, bank, owner, created_at, updated_at, is_deleted) values (?, ?, ?, ?, now(), now(), false)", 1L, "12345", "bank", "변현진");
+    }
+
+    @Test
+    @DisplayName("납부 상태 변경")
+    public void testUpdatePaymentStatus() throws Exception {
+        Method method = InvoiceSendingAndPaymentManageWriter.class.getDeclaredMethod("updatePaymentStatus", Long.class, long.class);
+        method.setAccessible(true);
+        method.invoke(writer, 1L, PAYMENT_STATUS_COMPLETED);
+        verify(jdbcTemplate).update("update invoice set payment_status_id = ?, updated_at = now() where invoice_id = ?", PAYMENT_STATUS_COMPLETED, 1L);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- [K5P-53]

## 구현 기능

- 약정일에 해당하는 청구 데이터를 대상으로 결제 및 청구서, 납부서 등 생성(발송) 배치 및 스케쥴러 구현 완료 
- JavaMailSender를 통해 결제 실패, 성공 메일 발송 로직 구현 / 납부자 결제인 경우 청구서 발송 로직 구현
- 편리하게 상태값 사용을 위한 util class 생성
- InvoiceSendingAndPaymentManageWriter 테스트 코드 작성
- 테스트 코드 작성을 위한 build.gradle 의존성 추가 
- 로그를 찍기위한 방법을 @Slf4j로 전환

## 참고 사항

- 아직 결제 로직은 만들어지지 않았습니다. (서버를 따로 만들 예정)
- 납부자 결제의 경우, 결제 기한(due_date) 값에 따른 납부 상태(payment_status) 값 변경 step이 추가될 예정입니다.
- 메세지 내용은 아직 구체적으로 만들지 않았습니다. 메일 내용에 있어 변경이 있을 예정입니다.

[K5P-53]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
