### PR TITLE
[K5P-54] [feat] 결제기한 지난 납부상태 변경 배치로직(납부자결제)

### DIFF
--- a/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/tasklet/CustomUpdateOverdueInvoicesTasklet.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/tasklet/CustomUpdateOverdueInvoicesTasklet.java
@@ -1,0 +1,31 @@
+package site.billingwise.batch.server_batch.batch.invoiceprocessing.tasklet;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import static site.billingwise.batch.server_batch.batch.util.StatusConstants.PAYMENT_STATUS_PENDING;
+import static site.billingwise.batch.server_batch.batch.util.StatusConstants.PAYMENT_STATUS_UNPAID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomUpdateOverdueInvoicesTasklet implements Tasklet {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        String sql = "update invoice set payment_status_id = ? where due_date < curdate() and payment_status_id = ? and is_deleted = false";
+        int updateRows = jdbcTemplate.update(sql, PAYMENT_STATUS_UNPAID, PAYMENT_STATUS_PENDING);
+
+        log.info("납부자 결제 대기에서 미납으로 전환된 청구 데이터 수: {}", updateRows);
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/test/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/tasklet/CustomUpdateOverdueInvoicesTaskletTest.java
+++ b/src/test/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/tasklet/CustomUpdateOverdueInvoicesTaskletTest.java
@@ -1,0 +1,56 @@
+package site.billingwise.batch.server_batch.batch.invoiceprocessing.tasklet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class CustomUpdateOverdueInvoicesTaskletTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @InjectMocks
+    private CustomUpdateOverdueInvoicesTasklet tasklet;
+
+    @Mock
+    private StepContribution stepContribution;
+
+    @Mock
+    private ChunkContext chunkContext;
+
+    private static final long PAYMENT_STATUS_UNPAID = 1L;
+    private static final long PAYMENT_STATUS_PENDING = 3L;
+
+    @BeforeEach
+    public void setUp() {
+        tasklet = new CustomUpdateOverdueInvoicesTasklet(jdbcTemplate);
+    }
+
+    @Test
+    @DisplayName("납부자 결제 미납 전환")
+    public void testExecute() throws Exception {
+
+        when(jdbcTemplate.update("update invoice set payment_status_id = ? where due_date < curdate() and payment_status_id = ? and is_deleted = false", PAYMENT_STATUS_UNPAID, PAYMENT_STATUS_PENDING))
+                .thenReturn(5);
+
+        RepeatStatus status = tasklet.execute(stepContribution, chunkContext);
+
+        verify(jdbcTemplate).update("update invoice set payment_status_id = ? where due_date < curdate() and payment_status_id = ? and is_deleted = false", PAYMENT_STATUS_UNPAID, PAYMENT_STATUS_PENDING);
+
+        assertEquals(RepeatStatus.FINISHED, status);
+
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- [K5P-54] 

## 구현 기능

결제 기한이 지난 납부 상태 변경
- 결제 기한이 지나고 납부 상태가 '대기'인 청구 테이블의 데이터를 '미납'으로 변경
- Tasklet으로 구현 
- Tasklet 사용 이유 : 단일 작업을 수행하는 쿼리문이며, 코드도 직관적이고 복잡한 로직에 의한 트랜잭션 관리가 별도로 필요하지 않다고 고려되었다. 
- 소프트 딜리트 된 데이터는 다루지 않는 쿼리

## 참고 사항

[K5P-54]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
