### PR TITLE
[K5P-53] [feat] 단건 계약(구독 상태 false) 계약 상태 변경 로직 추가

### DIFF
--- a/src/main/java/site/billingwise/batch/server_batch/batch/common/Scheduler.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/common/Scheduler.java
@@ -48,39 +48,16 @@ public class Scheduler {
 //        }
 //    }
 //
-    // 15, 45초마다 실행
-    @Scheduled(cron = "15,45 * * * * ?")
-    public void jdbcGenerateInvoice() {
-        JobParameters jobParameters = new JobParametersBuilder()
-                .addLong("jdbcInvoice", System.currentTimeMillis())
-                .toJobParameters();
-        try {
-            log.info("JDBC 배치 프로그램 실행 시작");
-            jobLauncher.run(jdbcGenerateInvoiceJob, jobParameters);
-            log.info("JDBC 배치 프로그램 실행 완료");
-        } catch (JobExecutionAlreadyRunningException e) {
-            log.error("JobExecutionAlreadyRunningException 발생: ", e);
-        } catch (JobRestartException e) {
-            log.error("JobRestartException 발생: ", e);
-        } catch (JobInstanceAlreadyCompleteException e) {
-            log.error("JobInstanceAlreadyCompleteException 발생: ", e);
-        } catch (JobParametersInvalidException e) {
-            log.error("JobParametersInvalidException 발생: ", e);
-        } catch (Exception e) {
-            log.error("예기치 않은 오류 발생: ", e);
-        }
-    }
-
 //    // 15, 45초마다 실행
 //    @Scheduled(cron = "15,45 * * * * ?")
-//    public void runInvoiceProcessingJob() {
+//    public void jdbcGenerateInvoice() {
 //        JobParameters jobParameters = new JobParametersBuilder()
-//                .addLong("InvoiceProcessingJob", System.currentTimeMillis())
+//                .addLong("jdbcInvoice", System.currentTimeMillis())
 //                .toJobParameters();
 //        try {
-//            log.info("Invoice Processing Job 실행 시작");
-//            jobLauncher.run(invoiceProcessingJob, jobParameters);
-//            log.info("Invoice Processing Job 실행 완료");
+//            log.info("JDBC 배치 프로그램 실행 시작");
+//            jobLauncher.run(jdbcGenerateInvoiceJob, jobParameters);
+//            log.info("JDBC 배치 프로그램 실행 완료");
 //        } catch (JobExecutionAlreadyRunningException e) {
 //            log.error("JobExecutionAlreadyRunningException 발생: ", e);
 //        } catch (JobRestartException e) {
@@ -93,5 +70,28 @@ public class Scheduler {
 //            log.error("예기치 않은 오류 발생: ", e);
 //        }
 //    }
+
+    // 15, 45초마다 실행
+    @Scheduled(cron = "15,45 * * * * ?")
+    public void runInvoiceProcessingJob() {
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLong("InvoiceProcessingJob", System.currentTimeMillis())
+                .toJobParameters();
+        try {
+            log.info("Invoice Processing Job 실행 시작");
+            jobLauncher.run(invoiceProcessingJob, jobParameters);
+            log.info("Invoice Processing Job 실행 완료");
+        } catch (JobExecutionAlreadyRunningException e) {
+            log.error("JobExecutionAlreadyRunningException 발생: ", e);
+        } catch (JobRestartException e) {
+            log.error("JobRestartException 발생: ", e);
+        } catch (JobInstanceAlreadyCompleteException e) {
+            log.error("JobInstanceAlreadyCompleteException 발생: ", e);
+        } catch (JobParametersInvalidException e) {
+            log.error("JobParametersInvalidException 발생: ", e);
+        } catch (Exception e) {
+            log.error("예기치 않은 오류 발생: ", e);
+        }
+    }
 }
 

--- a/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/config/InvoiceProcessingJobConfig.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/config/InvoiceProcessingJobConfig.java
@@ -72,7 +72,7 @@ public class InvoiceProcessingJobConfig {
         return new JdbcCursorItemReaderBuilder<Invoice>()
                 .name("invoiceSendingAndPaymentManageReader")
                 .fetchSize(CHUNK_SIZE)
-                .sql("select i.*, c.member_id, m.email, m.name, ca.number, ca.bank, ca.owner, i.is_deleted " +
+                .sql("select i.*, c.member_id, m.email, m.name, m.phone, ca.number, ca.bank, ca.owner, i.is_deleted, c.is_subscription " +
                         "from invoice i " +
                         "join contract c ON i.contract_id = c.contract_id " +
                         "join member m ON c.member_id = m.member_id " +

--- a/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/rowmapper/InvoiceRowMapper.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/rowmapper/InvoiceRowMapper.java
@@ -4,6 +4,7 @@ import org.springframework.jdbc.core.RowMapper;
 import site.billingwise.batch.server_batch.domain.contract.Contract;
 import site.billingwise.batch.server_batch.domain.contract.PaymentType;
 import site.billingwise.batch.server_batch.domain.invoice.Invoice;
+import site.billingwise.batch.server_batch.domain.invoice.InvoiceType;
 import site.billingwise.batch.server_batch.domain.member.ConsentAccount;
 import site.billingwise.batch.server_batch.domain.member.Member;
 
@@ -15,6 +16,9 @@ public class InvoiceRowMapper implements RowMapper<Invoice> {
     @Override
     public Invoice mapRow(ResultSet rs, int rowNum) throws SQLException {
 
+        InvoiceType invoiceType = InvoiceType.builder()
+                .id(rs.getLong("invoice_type_id"))
+                .build();
 
         ConsentAccount consentAccount = ConsentAccount.builder()
                 .number(rs.getString("number"))
@@ -27,12 +31,16 @@ public class InvoiceRowMapper implements RowMapper<Invoice> {
                 .id(rs.getLong("member_id"))
                 .email(rs.getString("email"))
                 .name(rs.getString("name"))
+                .phone(rs.getString("phone"))
                 .consentAccount(consentAccount)
                 .build();
 
 
         Contract contract = Contract.builder()
+                .id(rs.getLong("contract_id"))
                 .member(member)
+                .invoiceType(invoiceType)
+                .isSubscription(rs.getBoolean("is_subscription"))
                 .build();
 
         PaymentType paymentType = PaymentType.builder()

--- a/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/writer/InvoiceSendingAndPaymentManageWriter.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/writer/InvoiceSendingAndPaymentManageWriter.java
@@ -7,6 +7,7 @@ import org.springframework.batch.item.ItemWriter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import site.billingwise.batch.server_batch.batch.service.EmailService;
+import site.billingwise.batch.server_batch.domain.contract.Contract;
 import site.billingwise.batch.server_batch.domain.invoice.Invoice;
 import site.billingwise.batch.server_batch.domain.member.ConsentAccount;
 
@@ -28,8 +29,12 @@ public class InvoiceSendingAndPaymentManageWriter implements ItemWriter<Invoice>
             if(invoice.getIsDeleted()) {
                 continue;
             }
+
+            Contract contract = invoice.getContract();
+            boolean checkSubscription = contract.getIsSubscription();
+            long contract_id =  contract.getId();
             // 자동 이체
-            if(invoice.getPaymentType().getId() == INVOICE_TYPE_AUTOMATIC_BILLING) {
+            if(invoice.getPaymentType().getId() == PAYMENT_TYPE_AUTOMATIC_TRANSFER) {
 
                 ConsentAccount consentAccount = invoice.getContract().getMember().getConsentAccount();
                 boolean paymentAttempt = false;
@@ -45,26 +50,42 @@ public class InvoiceSendingAndPaymentManageWriter implements ItemWriter<Invoice>
                     updatePaymentStatus(invoice.getId(), PAYMENT_STATUS_COMPLETED);
                     insertPaymentRecord(invoice, consentAccount);
                     emailService.sendPaymentSuccessMailCode(invoice.getContract().getMember().getEmail(), invoice, consentAccount);
+                    // 단건일 경우( 계약 종료로 변경 )
+                    if(!checkSubscription) {
+                        updateNotSubscriptionContractStatus(contract_id, CONTRACT_STATUS_TERMINATED);
+                    }
 
-                // 결제 실패 시
+                    // 결제 실패 시
                 } else {
 
                     emailService.sendPaymentFailMailCode(invoice.getContract().getMember().getEmail(), invoice, consentAccount);
                     updateFailPaymentStatus(invoice.getId());
+                    // 단건일 경우( 계약 종료로 변경 )
+                    if(!checkSubscription) {
+                        updateNotSubscriptionContractStatus(contract_id, CONTRACT_STATUS_TERMINATED);
+                    }
                 }
 
-            // 납부자 결제
-            } else if(invoice.getPaymentType().getId() == INVOICE_TYPE_MANUAL_BILLING){
+                // 납부자 결제
+            } else if(invoice.getPaymentType().getId() == PAYMENT_TYPE_PAYER_PAYMENT){
 
                 emailService.sendInvoiceMail(invoice.getContract().getMember().getEmail(), invoice);
                 updatePaymentStatus(invoice.getId(), PAYMENT_STATUS_PENDING);
+                // 단건일 경우( 계약 종료로 변경 )
+                if(!checkSubscription) {
+                    updateNotSubscriptionContractStatus(contract_id, CONTRACT_STATUS_TERMINATED);
+                }
             }
         }
     }
 
+    private void updateNotSubscriptionContractStatus(long contract_id, long contractStatusTerminated){
+        String sql = "update contract set contract_status_id = ? where contract_id = ?";
+        jdbcTemplate.update(sql, contractStatusTerminated, contract_id);
+    }
 
 
-    private void updateFailPaymentStatus(Long invoiceId) {
+    private void updateFailPaymentStatus(long invoiceId) {
         String sql = "update invoice set updated_at = now() where invoice_id = ?";
         jdbcTemplate.update(sql,  invoiceId);
     }
@@ -72,19 +93,19 @@ public class InvoiceSendingAndPaymentManageWriter implements ItemWriter<Invoice>
 
     private void insertPaymentRecord(Invoice invoice, ConsentAccount consentAccount) {
         String sql = "insert into payment (invoice_id, payment_method, pay_amount, created_at, updated_at, is_deleted) values (?, ?, ?, NOW(), NOW(), false)";
-        jdbcTemplate.update(sql, invoice.getId(), "계좌이체", invoice.getChargeAmount());
+        jdbcTemplate.update(sql, invoice.getId(), "ACCOUNT", invoice.getChargeAmount());
         // 납부 계좌 테이블에 데이터 넣기 ( 결재 성공의 경우 )
         insertPaymentAccount(invoice.getId(), consentAccount);
     }
 
 
-    private void insertPaymentAccount(Long invoiceId, ConsentAccount consentAccount) {
+    private void insertPaymentAccount(long invoiceId, ConsentAccount consentAccount) {
         String sql = "insert into payment_account (invoice_id, number, bank, owner, created_at, updated_at, is_deleted) values (?, ?, ?, ?, now(), now(), false)";
         jdbcTemplate.update(sql, invoiceId, consentAccount.getNumber(), consentAccount.getBank(), consentAccount.getOwner());
     }
 
 
-    private void updatePaymentStatus(Long invoiceId, long statusId) {
+    private void updatePaymentStatus(long invoiceId, long statusId) {
         String sql = "update invoice set payment_status_id = ?, updated_at = now() where invoice_id = ?";
         jdbcTemplate.update(sql, statusId, invoiceId);
     }


### PR DESCRIPTION
## 관련 이슈

- [K5P-53] 

## 구현 기능

단건 계약의 경우 계약 상태 변경을 위한 로직 추가 
- 계약 테이블의 is_subscription 칼럼의 상태가 false인 경우, 정기적인
계약이 아니기에 해당 월의 청구 데이터를 처리하고 나면 계약 데이터의
계약 상태를 종료로 변경해준다. 


## 참고 사항

[K5P-53]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ