### PR TITLE
[K5P-61] [feat] 청구 및 수납 통계 배치

### DIFF
--- a/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/config/InvoiceProcessingJobConfig.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/invoiceprocessing/config/InvoiceProcessingJobConfig.java
@@ -35,7 +35,6 @@ public class InvoiceProcessingJobConfig {
     private final JobCompletionCheckListener jobCompletionCheckListener;
     private final EmailService emailService;
 
-    // 결제 기한 체크 로직 step 아직 개발 x
     @Bean
     public Job invoiceProcessingJob(JobRepository jobRepository, Step invoiceSendingAndPaymentManageStep, Step invoiceDueDateUpdateStep) {
         return new JobBuilder("InvoiceProcessingJob", jobRepository)

--- a/src/main/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/config/MonthlyInvoiceStatisticsJobConfig.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/config/MonthlyInvoiceStatisticsJobConfig.java
@@ -15,56 +15,51 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.ArgumentPreparedStatementSetter;
 import org.springframework.transaction.PlatformTransactionManager;
 import site.billingwise.batch.server_batch.batch.invoicestaticsprocessing.rowmapper.StaticsInvoiceRowMapper;
-import site.billingwise.batch.server_batch.batch.invoicestaticsprocessing.writer.CustomWeeklyInvoiceWriter;
+import site.billingwise.batch.server_batch.batch.invoicestaticsprocessing.writer.CustomMonthlyInvoiceWriter;
 import site.billingwise.batch.server_batch.batch.listner.JobCompletionCheckListener;
-import site.billingwise.batch.server_batch.batch.listner.statistic.WeeklyInvoiceStatisticsListener;
+import site.billingwise.batch.server_batch.batch.listner.statistic.MonthlyInvoiceStatisticsListener;
 import site.billingwise.batch.server_batch.domain.invoice.Invoice;
 
 import javax.sql.DataSource;
-import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 
 @Configuration
 @RequiredArgsConstructor
 @Slf4j
-public class WeeklyInvoiceStaticsJobConfig {
+public class MonthlyInvoiceStatisticsJobConfig {
 
     private final int CHUNK_SIZE = 100;
     private final DataSource dataSource;
     private final JobCompletionCheckListener jobCompletionCheckListener;
-    private final WeeklyInvoiceStatisticsListener weeklyInvoiceStatisticsListener;
-
+    private final MonthlyInvoiceStatisticsListener monthlyInvoiceStatisticsListener;
 
     @Bean
-    public Job weeklyInvoiceStatisticsJob(JobRepository jobRepository, Step weeklyInvoiceStatisticsStep) {
-        return new JobBuilder("weeklyInvoiceStatisticsJob", jobRepository)
+    public Job monthlyInvoiceStatisticsJob(JobRepository jobRepository, Step monthlyInvoiceStatisticsStep) {
+        return new JobBuilder("monthlyInvoiceStatisticsJob", jobRepository)
                 .listener(jobCompletionCheckListener)
-                .start(weeklyInvoiceStatisticsStep)
+                .start(monthlyInvoiceStatisticsStep)
                 .build();
     }
 
     @Bean
-    Step weeklyInvoiceStatisticsStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
-
-        return new StepBuilder("weeklyInvoiceStatisticsStep", jobRepository)
+    Step monthlyInvoiceStatisticsStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("monthlyInvoiceStatisticsStep", jobRepository)
                 .<Invoice, Invoice>chunk(CHUNK_SIZE, transactionManager)
-                .reader(weeklyInvoiceReader())
-                .writer(weeklyInvoiceWriter())
-                .listener(weeklyInvoiceStatisticsListener)
+                .reader(monthlyInvoiceReader())
+                .writer(monthlyInvoiceWriter())
+                .listener(monthlyInvoiceStatisticsListener)
                 .build();
-
     }
 
-
-    private ItemWriter<? super Invoice> weeklyInvoiceWriter() {
-        return new CustomWeeklyInvoiceWriter(weeklyInvoiceStatisticsListener);
+    private ItemWriter<? super Invoice> monthlyInvoiceWriter() {
+        return new CustomMonthlyInvoiceWriter(monthlyInvoiceStatisticsListener);
     }
 
-    private ItemReader<? extends Invoice> weeklyInvoiceReader() {
-        LocalDateTime startDate = LocalDateTime.now().minusWeeks(1).with(DayOfWeek.MONDAY);
-        LocalDateTime endDate = startDate.plusDays(6);
+    private ItemReader<? extends Invoice> monthlyInvoiceReader() {
+        LocalDateTime startDate = LocalDateTime.now().minusMonths(1).withDayOfMonth(1);
+        LocalDateTime endDate = startDate.plusMonths(1).minusDays(1);
         return new JdbcCursorItemReaderBuilder<Invoice>()
-                .name("weeklyInvoiceReader")
+                .name("monthlyInvoiceReader")
                 .dataSource(dataSource)
                 .fetchSize(CHUNK_SIZE)
                 .sql("SELECT i.*, c.member_id, m.client_id FROM invoice i " +
@@ -76,3 +71,4 @@ public class WeeklyInvoiceStaticsJobConfig {
                 .build();
     }
 }
+

--- a/src/main/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/config/WeeklyInvoiceStaticsJobConfig.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/config/WeeklyInvoiceStaticsJobConfig.java
@@ -1,0 +1,78 @@
+package site.billingwise.batch.server_batch.batch.invoicestaticsprocessing.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.builder.JdbcCursorItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.ArgumentPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import site.billingwise.batch.server_batch.batch.invoicestaticsprocessing.rowmapper.StaticsInvoiceRowMapper;
+import site.billingwise.batch.server_batch.batch.invoicestaticsprocessing.writer.CustomWeeklyInvoiceWriter;
+import site.billingwise.batch.server_batch.batch.listner.InvoiceStatisticsListener;
+import site.billingwise.batch.server_batch.batch.listner.JobCompletionCheckListener;
+import site.billingwise.batch.server_batch.domain.invoice.Invoice;
+
+import javax.sql.DataSource;
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class WeeklyInvoiceStaticsJobConfig {
+
+    private final int CHUNK_SIZE = 100;
+    private final DataSource dataSource;
+    private final JobCompletionCheckListener jobCompletionCheckListener;
+    private final InvoiceStatisticsListener invoiceStatisticsListener;
+
+
+    @Bean
+    public Job weeklyInvoiceStatisticsJob(JobRepository jobRepository, Step weeklyInvoiceStatisticsStep) {
+        return new JobBuilder("weeklyInvoiceStatisticsJob", jobRepository)
+                .listener(jobCompletionCheckListener)
+                .start(weeklyInvoiceStatisticsStep)
+                .build();
+    }
+
+    @Bean
+    Step weeklyInvoiceStatisticsStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+
+        return new StepBuilder("weeklyInvoiceStatisticsStep", jobRepository)
+                .<Invoice, Invoice>chunk(CHUNK_SIZE, transactionManager)
+                .reader(weeklyInvoiceReader())
+                .writer(weeklyInvoiceWriter())
+                .listener(invoiceStatisticsListener)
+                .build();
+
+    }
+
+
+    private ItemWriter<? super Invoice> weeklyInvoiceWriter() {
+        return new CustomWeeklyInvoiceWriter(invoiceStatisticsListener);
+    }
+
+    private ItemReader<? extends Invoice> weeklyInvoiceReader() {
+        LocalDateTime startDate = LocalDateTime.now().minusWeeks(1).with(DayOfWeek.MONDAY);
+        LocalDateTime endDate = startDate.plusDays(6);
+        return new JdbcCursorItemReaderBuilder<Invoice>()
+                .name("weeklyInvoiceReader")
+                .dataSource(dataSource)
+                .fetchSize(CHUNK_SIZE)
+                .sql("SELECT i.*, c.member_id, m.client_id FROM invoice i " +
+                        "JOIN contract c ON i.contract_id = c.contract_id  " +
+                        "JOIN member m ON c.member_id = m.member_id " +
+                        "WHERE i.due_date >= ? AND i.due_date <= ?")           .preparedStatementSetter(new ArgumentPreparedStatementSetter(new Object[]{startDate, endDate}))
+                .rowMapper(new StaticsInvoiceRowMapper())
+                .build();
+    }
+}

--- a/src/main/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/rowmapper/StaticsInvoiceRowMapper.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/rowmapper/StaticsInvoiceRowMapper.java
@@ -1,50 +1,40 @@
-package site.billingwise.batch.server_batch.batch.invoiceprocessing.rowmapper;
+package site.billingwise.batch.server_batch.batch.invoicestaticsprocessing.rowmapper;
 
 import org.springframework.jdbc.core.RowMapper;
 import site.billingwise.batch.server_batch.domain.contract.Contract;
 import site.billingwise.batch.server_batch.domain.contract.PaymentType;
 import site.billingwise.batch.server_batch.domain.invoice.Invoice;
-import site.billingwise.batch.server_batch.domain.invoice.InvoiceType;
-import site.billingwise.batch.server_batch.domain.member.ConsentAccount;
+import site.billingwise.batch.server_batch.domain.invoice.PaymentStatus;
 import site.billingwise.batch.server_batch.domain.member.Member;
+import site.billingwise.batch.server_batch.domain.user.Client;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-public class InvoiceRowMapper implements RowMapper<Invoice> {
-
+public class StaticsInvoiceRowMapper implements RowMapper<Invoice> {
     @Override
     public Invoice mapRow(ResultSet rs, int rowNum) throws SQLException {
 
-        InvoiceType invoiceType = InvoiceType.builder()
-                .id(rs.getLong("invoice_type_id"))
+        Client client = Client.builder()
+                .id(rs.getLong("client_id"))
                 .build();
-
-        ConsentAccount consentAccount = ConsentAccount.builder()
-                .number(rs.getString("number"))
-                .bank(rs.getString("bank"))
-                .owner(rs.getString("owner"))
-                .build();
-
 
         Member member = Member.builder()
                 .id(rs.getLong("member_id"))
-                .email(rs.getString("email"))
-                .name(rs.getString("name"))
-                .phone(rs.getString("phone"))
-                .consentAccount(consentAccount)
+                .client(client)
                 .build();
-
 
         Contract contract = Contract.builder()
                 .id(rs.getLong("contract_id"))
                 .member(member)
-                .invoiceType(invoiceType)
-                .isSubscription(rs.getBoolean("is_subscription"))
                 .build();
 
         PaymentType paymentType = PaymentType.builder()
                 .id(rs.getLong("payment_type_id"))
+                .build();
+
+        PaymentStatus paymentStatus = PaymentStatus.builder()
+                .id(rs.getLong("payment_status_id"))
                 .build();
 
 
@@ -55,7 +45,9 @@ public class InvoiceRowMapper implements RowMapper<Invoice> {
                 .contractDate(rs.getTimestamp("contract_date").toLocalDateTime())
                 .dueDate(rs.getTimestamp("due_date").toLocalDateTime())
                 .paymentType(paymentType)
+                .paymentStatus(paymentStatus)
                 .isDeleted(rs.getBoolean("is_deleted"))
                 .build();
+
     }
 }

--- a/src/main/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/writer/CustomMonthlyInvoiceWriter.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/writer/CustomMonthlyInvoiceWriter.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
-import site.billingwise.batch.server_batch.batch.listner.statistic.WeeklyInvoiceStatisticsListener;
+import site.billingwise.batch.server_batch.batch.listner.statistic.MonthlyInvoiceStatisticsListener;
 import site.billingwise.batch.server_batch.domain.invoice.Invoice;
 
 import static site.billingwise.batch.server_batch.batch.util.StatusConstants.*;
@@ -13,21 +13,19 @@ import static site.billingwise.batch.server_batch.batch.util.StatusConstants.*;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class CustomWeeklyInvoiceWriter implements ItemWriter<Invoice> {
+public class CustomMonthlyInvoiceWriter implements ItemWriter<Invoice> {
 
-    private final WeeklyInvoiceStatisticsListener invoiceStatisticsListener;
+    private final MonthlyInvoiceStatisticsListener invoiceStatisticsListener;
 
     @Override
     public void write(Chunk<? extends Invoice> chunk)  {
         for (Invoice invoice : chunk) {
 
-
             if (invoiceStatisticsListener.getClientId() == null) {
                 invoiceStatisticsListener.setClientId(invoice.getContract().getMember().getClient().getId());
             }
 
-
-            log.info("주간 통계 invoice 데이터 ID: {}", invoice.getId());
+            log.info("월간 통계 invoice 데이터 ID: {}", invoice.getId());
 
             if (invoice.getIsDeleted()) {
                 log.info("삭제된 invoice 데이터, skipping: {}", invoice.getId());

--- a/src/main/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/writer/CustomWeeklyInvoiceWriter.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/writer/CustomWeeklyInvoiceWriter.java
@@ -1,0 +1,53 @@
+package site.billingwise.batch.server_batch.batch.invoicestaticsprocessing.writer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+import site.billingwise.batch.server_batch.batch.listner.InvoiceStatisticsListener;
+import site.billingwise.batch.server_batch.domain.invoice.Invoice;
+
+import static site.billingwise.batch.server_batch.batch.util.StatusConstants.*;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomWeeklyInvoiceWriter implements ItemWriter<Invoice> {
+
+    private final InvoiceStatisticsListener invoiceStatisticsListener;
+
+    @Override
+    public void write(Chunk<? extends Invoice> chunk)  {
+        for (Invoice invoice : chunk) {
+
+
+            if (invoiceStatisticsListener.getClientId() == null) {
+                invoiceStatisticsListener.setClientId(invoice.getContract().getMember().getClient().getId());
+            }
+
+
+            log.info("주간 통계 invoice 데이터 ID: {}", invoice.getId());
+
+            if (invoice.getIsDeleted()) {
+                log.info("삭제된 invoice 데이터, skipping: {}", invoice.getId());
+                continue;
+            }
+            if (invoice.getPaymentStatus().getId() == PAYMENT_STATUS_PENDING) {
+                log.info("아직 결제 대기 중인 invoice 데이터, skipping: {}", invoice.getId());
+                continue;
+            }
+
+            invoiceStatisticsListener.addInvoice(invoice.getChargeAmount());
+            log.info("총 청구액에 더할 invoice 데이터 금액: {}", invoice.getChargeAmount());
+
+            if (invoice.getPaymentStatus().getId() == PAYMENT_STATUS_COMPLETED) {
+                invoiceStatisticsListener.addCollected(invoice.getChargeAmount());
+                log.info("총 수납금액에 더할 invoice 데이터 금액: {}", invoice.getChargeAmount());
+            } else if (invoice.getPaymentStatus().getId() == PAYMENT_STATUS_UNPAID) {
+                invoiceStatisticsListener.addOutstanding(invoice.getChargeAmount());
+                log.info("총 미납금액에 더할 invoice 데이터 금액: {}", invoice.getChargeAmount());
+            }
+        }
+    }
+}

--- a/src/main/java/site/billingwise/batch/server_batch/batch/listner/InvoiceStatisticsListener.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/listner/InvoiceStatisticsListener.java
@@ -1,0 +1,90 @@
+package site.billingwise.batch.server_batch.batch.listner;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+
+import static site.billingwise.batch.server_batch.batch.util.StatusConstants.STATISTICS_TYPE_WEEKLY;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class InvoiceStatisticsListener implements StepExecutionListener {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private long totalInvoicedMoney ;
+    private long totalCollectedMoney;
+    private long totalOutstanding;
+    private Long clientId;
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        log.info("afterStep 호출");
+        LocalDateTime today = LocalDateTime.now();
+        LocalDateTime startOfLastWeek = today.minusWeeks(1).with(DayOfWeek.MONDAY);
+        int weekNumber = startOfLastWeek.get(WeekFields.of(Locale.getDefault()).weekOfWeekBasedYear());
+        updateinvoiceStatics(jdbcTemplate,totalInvoicedMoney, totalCollectedMoney, totalOutstanding, startOfLastWeek, weekNumber);
+
+        return ExitStatus.COMPLETED;
+    }
+
+    private void updateinvoiceStatics(JdbcTemplate jdbcTemplate , long totalInvoicedMoney, long totalCollectedMoney, long totalOutstanding, LocalDateTime startOfLastWeek, int weekNumber) {
+        // 데이터 베이스에 insert하는 로직
+        // 참고날짜, 총 청구액, 총 수금액, 총 미납액, 타입상태(주간 or 월간), 년, 월, 주,
+        log.info("업데이트 invoice statistics 테이블: totalInvoicedMoney={}, totalCollectedMoney={}, totalOutstanding={}, startOfLastWeek={}, weekNumber={}",
+                totalInvoicedMoney, totalCollectedMoney, totalOutstanding, startOfLastWeek, weekNumber);
+
+
+        String sql = "insert into invoice_statistics (reference_date, total_invoiced, total_collected, outstanding, type_id, year, month, week, client_id, is_deleted, created_at, updated_at ) " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, false, now(), now())";
+        jdbcTemplate.update(sql,  startOfLastWeek,
+                totalInvoicedMoney,
+                totalCollectedMoney,
+                totalOutstanding,
+                STATISTICS_TYPE_WEEKLY,
+                startOfLastWeek.getYear(),
+                startOfLastWeek.getMonthValue(),
+                weekNumber,
+                clientId
+        );
+
+    }
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        totalInvoicedMoney = 0;
+        totalCollectedMoney = 0;
+        totalOutstanding = 0;
+        clientId = null;
+    }
+
+    public void addInvoice(long Invoice) {
+        totalInvoicedMoney += Invoice;
+    }
+
+    public void addCollected(long Collected) {
+        totalCollectedMoney += Collected;
+    }
+
+    public void addOutstanding(long outstanding) {
+        totalOutstanding += outstanding;
+    }
+
+    public void setClientId(Long id) {
+        this.clientId = id;
+    }
+
+    public Long getClientId() {
+        return clientId;
+    }
+}

--- a/src/main/java/site/billingwise/batch/server_batch/batch/listner/statistic/InvoiceStatisticsListener.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/listner/statistic/InvoiceStatisticsListener.java
@@ -36,7 +36,7 @@ public abstract class InvoiceStatisticsListener implements StepExecutionListener
         // 통계 타입에 따라 시작 날짜와 기간 번호를 설정하기
         if (getStatisticsType() == StatusConstants.STATISTICS_TYPE_MONTHLY) {
             startOfPeriod = today.minusMonths(1).withDayOfMonth(1);
-            periodNumber = startOfPeriod.getMonthValue();
+            periodNumber = 0; // 월간일 경우에는 주간 데이터 0
         } else {
             startOfPeriod = today.minusWeeks(1).with(DayOfWeek.MONDAY);
             periodNumber = startOfPeriod.get(WeekFields.of(Locale.getDefault()).weekOfWeekBasedYear());

--- a/src/main/java/site/billingwise/batch/server_batch/batch/listner/statistic/InvoiceStatisticsListener.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/listner/statistic/InvoiceStatisticsListener.java
@@ -1,4 +1,4 @@
-package site.billingwise.batch.server_batch.batch.listner;
+package site.billingwise.batch.server_batch.batch.listner.statistic;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -6,19 +6,18 @@ import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.StepExecutionListener;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.stereotype.Component;
+import site.billingwise.batch.server_batch.batch.util.StatusConstants;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.temporal.WeekFields;
 import java.util.Locale;
 
-import static site.billingwise.batch.server_batch.batch.util.StatusConstants.STATISTICS_TYPE_WEEKLY;
-
-@Component
 @RequiredArgsConstructor
 @Slf4j
-public class InvoiceStatisticsListener implements StepExecutionListener {
+public abstract class InvoiceStatisticsListener implements StepExecutionListener {
+
+    protected abstract Long getStatisticsType();
 
     private final JdbcTemplate jdbcTemplate;
 
@@ -31,30 +30,40 @@ public class InvoiceStatisticsListener implements StepExecutionListener {
     public ExitStatus afterStep(StepExecution stepExecution) {
         log.info("afterStep 호출");
         LocalDateTime today = LocalDateTime.now();
-        LocalDateTime startOfLastWeek = today.minusWeeks(1).with(DayOfWeek.MONDAY);
-        int weekNumber = startOfLastWeek.get(WeekFields.of(Locale.getDefault()).weekOfWeekBasedYear());
-        updateinvoiceStatics(jdbcTemplate,totalInvoicedMoney, totalCollectedMoney, totalOutstanding, startOfLastWeek, weekNumber);
+        LocalDateTime startOfPeriod;
+        int periodNumber;
 
+        // 통계 타입에 따라 시작 날짜와 기간 번호를 설정하기
+        if (getStatisticsType() == StatusConstants.STATISTICS_TYPE_MONTHLY) {
+            startOfPeriod = today.minusMonths(1).withDayOfMonth(1);
+            periodNumber = startOfPeriod.getMonthValue();
+        } else {
+            startOfPeriod = today.minusWeeks(1).with(DayOfWeek.MONDAY);
+            periodNumber = startOfPeriod.get(WeekFields.of(Locale.getDefault()).weekOfWeekBasedYear());
+        }
+
+
+        updateinvoiceStatics(jdbcTemplate,totalInvoicedMoney, totalCollectedMoney, totalOutstanding, startOfPeriod, periodNumber);
         return ExitStatus.COMPLETED;
     }
 
-    private void updateinvoiceStatics(JdbcTemplate jdbcTemplate , long totalInvoicedMoney, long totalCollectedMoney, long totalOutstanding, LocalDateTime startOfLastWeek, int weekNumber) {
+    private void updateinvoiceStatics(JdbcTemplate jdbcTemplate , long totalInvoicedMoney, long totalCollectedMoney, long totalOutstanding, LocalDateTime startOfPeriod, int periodNumber) {
         // 데이터 베이스에 insert하는 로직
         // 참고날짜, 총 청구액, 총 수금액, 총 미납액, 타입상태(주간 or 월간), 년, 월, 주,
         log.info("업데이트 invoice statistics 테이블: totalInvoicedMoney={}, totalCollectedMoney={}, totalOutstanding={}, startOfLastWeek={}, weekNumber={}",
-                totalInvoicedMoney, totalCollectedMoney, totalOutstanding, startOfLastWeek, weekNumber);
+                totalInvoicedMoney, totalCollectedMoney, totalOutstanding, startOfPeriod, periodNumber);
 
 
         String sql = "insert into invoice_statistics (reference_date, total_invoiced, total_collected, outstanding, type_id, year, month, week, client_id, is_deleted, created_at, updated_at ) " +
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, false, now(), now())";
-        jdbcTemplate.update(sql,  startOfLastWeek,
+        jdbcTemplate.update(sql,  startOfPeriod,
                 totalInvoicedMoney,
                 totalCollectedMoney,
                 totalOutstanding,
-                STATISTICS_TYPE_WEEKLY,
-                startOfLastWeek.getYear(),
-                startOfLastWeek.getMonthValue(),
-                weekNumber,
+                getStatisticsType(),
+                startOfPeriod.getYear(),
+                startOfPeriod.getMonthValue(),
+                periodNumber,
                 clientId
         );
 
@@ -87,4 +96,5 @@ public class InvoiceStatisticsListener implements StepExecutionListener {
     public Long getClientId() {
         return clientId;
     }
+
 }

--- a/src/main/java/site/billingwise/batch/server_batch/batch/listner/statistic/MonthlyInvoiceStatisticsListener.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/listner/statistic/MonthlyInvoiceStatisticsListener.java
@@ -1,0 +1,20 @@
+package site.billingwise.batch.server_batch.batch.listner.statistic;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import site.billingwise.batch.server_batch.batch.util.StatusConstants;
+
+@Component
+@Slf4j
+public class MonthlyInvoiceStatisticsListener extends InvoiceStatisticsListener {
+
+    public MonthlyInvoiceStatisticsListener(JdbcTemplate jdbcTemplate) {
+        super(jdbcTemplate);
+    }
+
+    @Override
+    protected Long getStatisticsType() {
+        return StatusConstants.STATISTICS_TYPE_MONTHLY;
+    }
+}

--- a/src/main/java/site/billingwise/batch/server_batch/batch/listner/statistic/WeeklyInvoiceStatisticsListener.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/listner/statistic/WeeklyInvoiceStatisticsListener.java
@@ -1,0 +1,20 @@
+package site.billingwise.batch.server_batch.batch.listner.statistic;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import site.billingwise.batch.server_batch.batch.util.StatusConstants;
+
+@Component
+@Slf4j
+public class WeeklyInvoiceStatisticsListener extends InvoiceStatisticsListener {
+
+    public WeeklyInvoiceStatisticsListener(JdbcTemplate jdbcTemplate) {
+        super(jdbcTemplate);
+    }
+
+    @Override
+    protected Long getStatisticsType() {
+        return StatusConstants.STATISTICS_TYPE_WEEKLY;
+    }
+}

--- a/src/main/java/site/billingwise/batch/server_batch/batch/scheduler/Scheduler.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/scheduler/Scheduler.java
@@ -25,8 +25,9 @@ public class Scheduler {
     private final Job jdbcGenerateInvoiceJob;
     private final Job invoiceProcessingJob;
     private final Job weeklyInvoiceStatisticsJob;
+    private final Job monthlyInvoiceStatisticsJob;
 
-
+//
 //    // 0, 30초마다 실행
 //    @Scheduled(cron = "0,30 * * * * ?")
 //    public void generateInvoice() {
@@ -72,8 +73,8 @@ public class Scheduler {
 //            log.error("예기치 않은 오류 발생: ", e);
 //        }
 //    }
-
-    // 15, 45초마다 실행
+//
+////     15, 45초마다 실행monthlyInvoiceStatisticsJob
 //    @Scheduled(cron = "15,45 * * * * ?")
 //    public void runInvoiceProcessingJob() {
 //        JobParameters jobParameters = new JobParametersBuilder()
@@ -119,7 +120,32 @@ public class Scheduler {
             log.error("예기치 않은 오류 발생: ", e);
         }
     }
-}
+
+//        @Scheduled(cron = "0 0 1 1 * ?") // 매월 1일 새벽 1시
+        @Scheduled(cron = "0,30 * * * * ?")
+        public void monthlyJob() {
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addLong("monthlyInvoiceStatisticsJob", System.currentTimeMillis())
+                    .toJobParameters();
+            try {
+                log.info("monthlyInvoiceStatisticsJob 실행 시작");
+                jobLauncher.run(monthlyInvoiceStatisticsJob, jobParameters);
+                log.info("monthlyInvoiceStatisticsJob 실행 완료");
+            } catch (JobExecutionAlreadyRunningException e) {
+                log.error("JobExecutionAlreadyRunningException 발생: ", e);
+            } catch (JobRestartException e) {
+                log.error("JobRestartException 발생: ", e);
+            } catch (JobInstanceAlreadyCompleteException e) {
+                log.error("JobInstanceAlreadyCompleteException 발생: ", e);
+            } catch (JobParametersInvalidException e) {
+                log.error("JobParametersInvalidException 발생: ", e);
+            } catch (Exception e) {
+                log.error("예기치 않은 오류 발생: ", e);
+            }
+
+        }
+    }
+
 
 
 

--- a/src/main/java/site/billingwise/batch/server_batch/batch/scheduler/Scheduler.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/scheduler/Scheduler.java
@@ -1,4 +1,4 @@
-package site.billingwise.batch.server_batch.batch.common;
+package site.billingwise.batch.server_batch.batch.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +24,8 @@ public class Scheduler {
     private final Job generateInvoiceJob;
     private final Job jdbcGenerateInvoiceJob;
     private final Job invoiceProcessingJob;
+    private final Job weeklyInvoiceStatisticsJob;
+
 
 //    // 0, 30초마다 실행
 //    @Scheduled(cron = "0,30 * * * * ?")
@@ -72,15 +74,39 @@ public class Scheduler {
 //    }
 
     // 15, 45초마다 실행
+//    @Scheduled(cron = "15,45 * * * * ?")
+//    public void runInvoiceProcessingJob() {
+//        JobParameters jobParameters = new JobParametersBuilder()
+//                .addLong("InvoiceProcessingJob", System.currentTimeMillis())
+//                .toJobParameters();
+//        try {
+//            log.info("Invoice Processing Job 실행 시작");
+//            jobLauncher.run(invoiceProcessingJob, jobParameters);
+//            log.info("Invoice Processing Job 실행 완료");
+//        } catch (JobExecutionAlreadyRunningException e) {
+//            log.error("JobExecutionAlreadyRunningException 발생: ", e);
+//        } catch (JobRestartException e) {
+//            log.error("JobRestartException 발생: ", e);
+//        } catch (JobInstanceAlreadyCompleteException e) {
+//            log.error("JobInstanceAlreadyCompleteException 발생: ", e);
+//        } catch (JobParametersInvalidException e) {
+//            log.error("JobParametersInvalidException 발생: ", e);
+//        } catch (Exception e) {
+//            log.error("예기치 않은 오류 발생: ", e);
+//        }
+//    }
+
+
+    //        @Scheduled(cron = "0 0 1 * * SUN") // 매주 일요일 새벽 1시에 실행
     @Scheduled(cron = "15,45 * * * * ?")
-    public void runInvoiceProcessingJob() {
+    public void weeklyJob() {
         JobParameters jobParameters = new JobParametersBuilder()
-                .addLong("InvoiceProcessingJob", System.currentTimeMillis())
+                .addLong("weeklyInvoiceStatisticsJob", System.currentTimeMillis())
                 .toJobParameters();
         try {
-            log.info("Invoice Processing Job 실행 시작");
-            jobLauncher.run(invoiceProcessingJob, jobParameters);
-            log.info("Invoice Processing Job 실행 완료");
+            log.info("weeklyInvoiceStatisticsJob 실행 시작");
+            jobLauncher.run(weeklyInvoiceStatisticsJob, jobParameters);
+            log.info("weeklyInvoiceStatisticsJob 실행 완료");
         } catch (JobExecutionAlreadyRunningException e) {
             log.error("JobExecutionAlreadyRunningException 발생: ", e);
         } catch (JobRestartException e) {
@@ -94,4 +120,6 @@ public class Scheduler {
         }
     }
 }
+
+
 

--- a/src/main/java/site/billingwise/batch/server_batch/batch/util/StatusConstants.java
+++ b/src/main/java/site/billingwise/batch/server_batch/batch/util/StatusConstants.java
@@ -20,4 +20,10 @@ public class StatusConstants {
     public static final long PAYMENT_TYPE_PAYER_PAYMENT = 1L;   // 납부자 결제
     public static final long PAYMENT_TYPE_AUTOMATIC_TRANSFER = 2L;   // 자동 이체
 
+
+    // 통계 타입
+    public static final long STATISTICS_TYPE_WEEKLY = 1L; // 주간 통계
+    public static final long STATISTICS_TYPE_MONTHLY = 2L; // 월간 통계
+
+
 }

--- a/src/main/java/site/billingwise/batch/server_batch/domain/statics/InvoiceStatistics.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/statics/InvoiceStatistics.java
@@ -1,0 +1,52 @@
+package site.billingwise.batch.server_batch.domain.statics;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import site.billingwise.batch.server_batch.domain.common.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name="invoice_statistics")
+public class InvoiceStatistics extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "reference_date", nullable = false)
+    private LocalDateTime date;
+
+    @Column(name = "total_invoiced", nullable = false)
+    private Long totalInvoiced;
+
+    @Column(name = "total_collected", nullable = false)
+    private Long totalCollected;
+
+    @Column(name = "outstanding", nullable = false)
+    private Long outstanding;
+
+    @Column(nullable = false)
+    private Integer year;
+
+    @Column(nullable = true)
+    private Integer month;
+
+    @Column(nullable = true)
+    private Integer week;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "type_id", nullable = false)
+    private InvoiceStatisticsType type;
+
+    @Column(name = "client_id", nullable = false)
+    private Long clientId;
+}

--- a/src/main/java/site/billingwise/batch/server_batch/domain/statics/InvoiceStatisticsType.java
+++ b/src/main/java/site/billingwise/batch/server_batch/domain/statics/InvoiceStatisticsType.java
@@ -1,0 +1,32 @@
+package site.billingwise.batch.server_batch.domain.statics;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import site.billingwise.batch.server_batch.domain.common.BaseEntity;
+import site.billingwise.batch.server_batch.domain.contract.Contract;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name="invoice_statistics_type")
+public class InvoiceStatisticsType extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "type_name", nullable = false)
+    private String typeName;
+
+    @OneToMany(mappedBy = "type", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<InvoiceStatistics> invoiceStatisticsList;
+}

--- a/src/main/resources/status.sql
+++ b/src/main/resources/status.sql
@@ -28,3 +28,39 @@ VALUES
     (1, '미납', false, NOW(), NOW()),
     (2, '완납', false, NOW(), NOW()),
     (3, '대기', false, NOW(), NOW());
+
+
+
+
+-- 통계 구분 값
+INSERT INTO invoice_statistics_type (type_name, is_deleted)
+VALUES
+    ('주간', false),
+    ('월간', false);
+
+
+-- 통계 테이블 생성 쿼리
+CREATE TABLE invoice_statistics_type (
+                                         id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                         type_name VARCHAR(50) NOT NULL,
+                                         is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+                                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE invoice_statistics (
+                                    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                    reference_date TIMESTAMP NOT NULL,
+                                    total_invoiced BIGINT NOT NULL,
+                                    total_collected BIGINT NOT NULL,
+                                    outstanding BIGINT NOT NULL,
+                                    type_id BIGINT NOT NULL,
+                                    year INT NOT NULL,
+                                    month INT DEFAULT NULL,
+                                    week INT DEFAULT NULL,
+                                    client_id BIGINT NOT NULL,
+                                    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+                                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                                    FOREIGN KEY (type_id) REFERENCES invoice_statistics_type(id)
+);

--- a/src/test/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/writer/CustomMonthlyInvoiceWriterTest.java
+++ b/src/test/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/writer/CustomMonthlyInvoiceWriterTest.java
@@ -1,0 +1,123 @@
+package site.billingwise.batch.server_batch.batch.invoicestaticsprocessing.writer;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.batch.item.Chunk;
+
+import site.billingwise.batch.server_batch.batch.invoicestaticsprocessing.writer.CustomMonthlyInvoiceWriter;
+import site.billingwise.batch.server_batch.batch.listner.statistic.MonthlyInvoiceStatisticsListener;
+import site.billingwise.batch.server_batch.domain.contract.Contract;
+import site.billingwise.batch.server_batch.domain.invoice.Invoice;
+import site.billingwise.batch.server_batch.domain.invoice.PaymentStatus;
+import site.billingwise.batch.server_batch.domain.member.Member;
+import site.billingwise.batch.server_batch.domain.user.Client;
+
+public class CustomMonthlyInvoiceWriterTest {
+
+    @Mock
+    private MonthlyInvoiceStatisticsListener invoiceStatisticsListener;
+
+    @InjectMocks
+    private CustomMonthlyInvoiceWriter writer;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        writer = new CustomMonthlyInvoiceWriter(invoiceStatisticsListener);
+    }
+
+    @Test
+    public void testWrite() throws Exception {
+
+        Client client = Client.builder().id(1L).build();
+        Member member = Member.builder().client(client).build();
+        Contract contract = Contract.builder().member(member).build();
+        PaymentStatus paymentStatus = PaymentStatus.builder().id(2L).build();
+
+        Invoice invoice = Invoice.builder()
+                .id(1L)
+                .contract(contract)
+                .chargeAmount(1000L)
+                .paymentStatus(paymentStatus)
+                .isDeleted(false)
+                .build();
+
+        when(invoiceStatisticsListener.getClientId()).thenReturn(null);
+
+        Chunk<Invoice> chunk = new Chunk<>(List.of(invoice));
+
+
+        writer.write(chunk);
+
+        verify(invoiceStatisticsListener, times(1)).setClientId(client.getId());
+        verify(invoiceStatisticsListener, times(1)).addInvoice(invoice.getChargeAmount());
+        verify(invoiceStatisticsListener, times(1)).addCollected(invoice.getChargeAmount());
+    }
+
+    @Test
+    public void testWriteWithPendingInvoice() throws Exception {
+
+        Client client = Client.builder().id(1L).build();
+        Member member = Member.builder().client(client).build();
+        Contract contract = Contract.builder().member(member).build();
+        PaymentStatus paymentStatus = PaymentStatus.builder().id(3L).build();
+
+        Invoice invoice = Invoice.builder()
+                .id(1L)
+                .contract(contract)
+                .chargeAmount(1000L)
+                .paymentStatus(paymentStatus)
+                .isDeleted(false)
+                .build();
+
+        when(invoiceStatisticsListener.getClientId()).thenReturn(null);
+
+        Chunk<Invoice> chunk = new Chunk<>(List.of(invoice));
+
+
+        writer.write(chunk);
+
+
+        verify(invoiceStatisticsListener, times(1)).setClientId(client.getId());
+        verify(invoiceStatisticsListener, never()).addInvoice(anyLong());
+        verify(invoiceStatisticsListener, never()).addCollected(anyLong());
+        verify(invoiceStatisticsListener, never()).addOutstanding(anyLong());
+    }
+
+    @Test
+    public void testWriteWithDeletedInvoice() throws Exception {
+        // Given
+        Client client = Client.builder().id(1L).build();
+        Member member = Member.builder().client(client).build();
+        Contract contract = Contract.builder().member(member).build();
+        PaymentStatus paymentStatus = PaymentStatus.builder().id(2L).build();
+
+        Invoice invoice = Invoice.builder()
+                .id(1L)
+                .contract(contract)
+                .chargeAmount(1000L)
+                .paymentStatus(paymentStatus)
+                .isDeleted(true)
+                .build();
+
+        when(invoiceStatisticsListener.getClientId()).thenReturn(null);
+
+        Chunk<Invoice> chunk = new Chunk<>(List.of(invoice));
+
+        // When
+        writer.write(chunk);
+
+        // Then
+        verify(invoiceStatisticsListener, times(1)).setClientId(client.getId());
+        verify(invoiceStatisticsListener, never()).addInvoice(anyLong());
+        verify(invoiceStatisticsListener, never()).addCollected(anyLong());
+        verify(invoiceStatisticsListener, never()).addOutstanding(anyLong());
+    }
+}

--- a/src/test/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/writer/CustomWeeklyInvoiceWriterTest.java
+++ b/src/test/java/site/billingwise/batch/server_batch/batch/invoicestaticsprocessing/writer/CustomWeeklyInvoiceWriterTest.java
@@ -1,0 +1,125 @@
+package site.billingwise.batch.server_batch.batch.invoicestaticsprocessing.writer;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.batch.item.Chunk;
+
+import site.billingwise.batch.server_batch.batch.invoicestaticsprocessing.writer.CustomWeeklyInvoiceWriter;
+import site.billingwise.batch.server_batch.batch.listner.statistic.WeeklyInvoiceStatisticsListener;
+
+import site.billingwise.batch.server_batch.domain.contract.Contract;
+import site.billingwise.batch.server_batch.domain.invoice.Invoice;
+import site.billingwise.batch.server_batch.domain.invoice.PaymentStatus;
+import site.billingwise.batch.server_batch.domain.member.Member;
+import site.billingwise.batch.server_batch.domain.user.Client;
+
+public class CustomWeeklyInvoiceWriterTest {
+
+    @Mock
+    private WeeklyInvoiceStatisticsListener invoiceStatisticsListener;
+
+    @InjectMocks
+    private CustomWeeklyInvoiceWriter writer;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        writer = new CustomWeeklyInvoiceWriter(invoiceStatisticsListener);
+    }
+
+    @Test
+    public void testWrite() throws Exception {
+
+        Client client = Client.builder().id(1L).build();
+        Member member = Member.builder().client(client).build();
+        Contract contract = Contract.builder().member(member).build();
+        PaymentStatus paymentStatus = PaymentStatus.builder().id(2L).build();
+
+        Invoice invoice = Invoice.builder()
+                .id(1L)
+                .contract(contract)
+                .chargeAmount(1000L)
+                .paymentStatus(paymentStatus)
+                .isDeleted(false)
+                .build();
+
+        when(invoiceStatisticsListener.getClientId()).thenReturn(null);
+
+        Chunk<Invoice> chunk = new Chunk<>(List.of(invoice));
+
+
+        writer.write(chunk);
+
+
+        verify(invoiceStatisticsListener, times(1)).setClientId(client.getId());
+        verify(invoiceStatisticsListener, times(1)).addInvoice(invoice.getChargeAmount());
+        verify(invoiceStatisticsListener, times(1)).addCollected(invoice.getChargeAmount());
+    }
+
+    @Test
+    public void testWriteWithPendingInvoice() throws Exception {
+        // Given
+        Client client = Client.builder().id(1L).build();
+        Member member = Member.builder().client(client).build();
+        Contract contract = Contract.builder().member(member).build();
+        PaymentStatus paymentStatus = PaymentStatus.builder().id(3L).build();
+
+        Invoice invoice = Invoice.builder()
+                .id(1L)
+                .contract(contract)
+                .chargeAmount(1000L)
+                .paymentStatus(paymentStatus)
+                .isDeleted(false)
+                .build();
+
+        when(invoiceStatisticsListener.getClientId()).thenReturn(null);
+
+        Chunk<Invoice> chunk = new Chunk<>(List.of(invoice));
+
+        // When
+        writer.write(chunk);
+
+        // Then
+        verify(invoiceStatisticsListener, times(1)).setClientId(client.getId());
+        verify(invoiceStatisticsListener, never()).addInvoice(anyLong());
+        verify(invoiceStatisticsListener, never()).addCollected(anyLong());
+        verify(invoiceStatisticsListener, never()).addOutstanding(anyLong());
+    }
+
+    @Test
+    public void testWriteWithDeletedInvoice() throws Exception {
+        // Given
+        Client client = Client.builder().id(1L).build();
+        Member member = Member.builder().client(client).build();
+        Contract contract = Contract.builder().member(member).build();
+        PaymentStatus paymentStatus = PaymentStatus.builder().id(2L).build();
+
+        Invoice invoice = Invoice.builder()
+                .id(1L)
+                .contract(contract)
+                .chargeAmount(1000L)
+                .paymentStatus(paymentStatus)
+                .isDeleted(true)
+                .build();
+
+        when(invoiceStatisticsListener.getClientId()).thenReturn(null);
+
+        Chunk<Invoice> chunk = new Chunk<>(List.of(invoice));
+
+        // When
+        writer.write(chunk);
+
+        // Then
+        verify(invoiceStatisticsListener, times(1)).setClientId(client.getId());
+        verify(invoiceStatisticsListener, never()).addInvoice(anyLong());
+        verify(invoiceStatisticsListener, never()).addCollected(anyLong());
+        verify(invoiceStatisticsListener, never()).addOutstanding(anyLong());
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- [K5P-61] 

## 구현 기능

- 주간, 월간 청구액 및 수납액/미납액 집계 배치 구현
- 집계 관련 테이블 및 엔티티 추가
- 상태값 추가 및 테이블 생성 쿼리문 작성
- 테스트 코드 작성 
- stepListener를 통한 집계값 계산 후 insert

  - 청크 단위로 처리한다고 해도 만약 한달 또는 주간 invoice 데이터가 out of memory를 발생시킬 수 있는 정도의 크기라면 하나의 트랜잭션으로 집계값을 처리하여 레코드로 생성이 불가능하다고 판단하여 stepListener를 통해 처리함.
- statisticsType이 덮어쓰여지는 문제 해결
  
  - 기존에는 월간/ 주간 두 개의 job이 모두 InvoiceStatisticsListener를 사용하는 형태였으나, 두 개의 job을 연달아 실행시켜본 결과, statisticsType이 하나로 유지되는 현상을 보임. 아마도 싱글톤으로 관리되는 문제로 인해 statisticsType이 덮어쓰여지는 문제로 판단되어 WeeklyInvoiceStatisticsListener와 MonthlyInvoiceStatisticsListener를 각각 정의하고, 각 작업에 대해 해당 리스너를 사용하도록 설정하여 상태값이 덮여쓰여지는 문제를 해결 


## 참고 사항

- 스케줄러의 시간 설정은 아직 테스트를 위해 임시로 지정한 값들 입니다. 

[K5P-61]: https://hyosung-kosa-team5.atlassian.net/browse/K5P-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ